### PR TITLE
Removes Group Buddies references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,8 @@ Credits
 
 Thanks to [thoughtbot](http://thoughtbot.com/) from whom this guides are based.
 
-![groupbuddies](http://www.groupbuddies.com/logo.png)
+This guides are maintained by [Subvisual](https://subvisual.co)
+The names and logos for Subvisual are trademarks of GB-Software As A Service, Lda.
 
-This guides are maintained by [Group Buddies](http://groupbuddies.com)
-The names and logos for Group Buddies are trademarks of GB-Software As A Service, Lda.
-
-This guides are © 2014 GB-Software As A Service, Lda. They are distributed under the [Creative Commons
+This guides are © 2015 GB-Software As A Service, Lda. They are distributed under the [Creative Commons
 Attribution License](http://creativecommons.org/licenses/by/3.0/).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,19 +2,19 @@
 
 A guide for deploying web apps in a sane and repeatable way
 
-**NOTE:** everything described here should be replicated in the [example app](https://github.com/groupbuddies/gb-puppet-test-app)
+**NOTE:** everything described here should be replicated in the [example app](https://github.com/subvisual/gb-puppet-test-app)
 
 # Server setup
 
 * Use [DigitalOcean](https://www.digitalocean.com/). Be sure to select the `Enable Backups` feature, which can only be enabled during creation
 * Use Ubuntu 12.04 (Precise Pangolin) x64, unless you have specific reasons to do otherwise (upstart has issues in later versions)
-* Provision the server using [GB Puppet](https://github.com/groupbuddies/gb-puppet). Follow the README there for the appropriate steps.
+* Provision the server using [GB Puppet](https://github.com/subvisual/gb-puppet). Follow the README there for the appropriate steps.
 * After the initial setup, avoid SSH'ing to the server, unless strictly necessary.
 * Store all required data (passwords, IP address, any decisions made, etc) in a secure location, but accessible to the team
 
 # App setup
 
-* Provision the app using [GB Puppet's app provisioning script](https://github.com/groupbuddies/gb-puppet). Follow the README there for the appropriate steps.
+* Provision the app using [Subvisual Puppet's app provisioning script](https://github.com/subvisual/gb-puppet). Follow the README there for the appropriate steps.
 * Never include sensitive production data in the repo (even if it's private)
 * Include a `Procfile.production` (and `Procfile.staging`, if applicable)
 * A `.env` file should exist in the server with all env data required (including PATH)
@@ -22,5 +22,5 @@ A guide for deploying web apps in a sane and repeatable way
 
 # Provision the machine
 
-* Have manifest files to provision the machine with anything the app needs (ruby, Node.js, a Postgres database, etc). Check the [example app](https://github.com/groupbuddies/gb-puppet-test-app) for more details.
+* Have manifest files to provision the machine with anything the app needs (ruby, Node.js, a Postgres database, etc). Check the [example app](https://github.com/subvisual/gb-puppet-test-app) for more details.
 * Keep sensitive data (i.e. system passwords) outside the repo.

--- a/github/README.md
+++ b/github/README.md
@@ -23,4 +23,4 @@ Working on Issues/Pull Requests
 * If you're working on an issue, assign it to yourself.
 * Submit a Pull Request with the fix.
 * If your Pull Requests fixes one or more issues, link to them in the discussion.
-* Tag a person (or [team](https://github.com/orgs/groupbuddies/teams)) if you need their input specifically.
+* Tag a person (or [team](https://github.com/orgs/subvisual/teams)) if you need their input specifically.

--- a/protocol/communication/README.md
+++ b/protocol/communication/README.md
@@ -18,7 +18,7 @@ Github
 
 * Open Github issues to file bug reports, and to suggest small improvements or refactors.
 * Define labels and milestones in your issues, if applicable.
-* Tag a person (or [team](https://github.com/orgs/groupbuddies/teams)) if you need their input specifically.
+* Tag a person (or [team](https://github.com/orgs/subvisual/teams)) if you need their input specifically.
 * If your Pull Requests fixes one or more issues, link to them in the discussion.
 * If you're working on an issue, assign it to yourself.
 
@@ -37,4 +37,3 @@ project maybe someone else can pitch in or at least read it, if not use the #ran
 If the conversation does not fit any of the channels, question
 yourself if you should be having it on the company's Slack.
 * Prefer using `@channel`, which applies only to the people already on a channel.
-

--- a/protocol/rails/README.md
+++ b/protocol/rails/README.md
@@ -11,8 +11,7 @@ Create Rails app
     rails new dummy
 
 * Create a github repo on http://github.com/new and follow the instructions to add
-your code to the repo. Create the repo on the groupbuddies organizations. Create
-the repo on the groupbuddies organization.
+your code to the repo. Create the repo on the Subvisual organizations.
 
 * Create a `dev` branch.
 
@@ -25,7 +24,7 @@ Set up Rails app
 Set up the app's dependencies.
 
     cd your/projects/folder
-    git clone git@github.com:groupbuddies/name-of-the-app.git
+    git clone git@github.com:subvisual/name-of-the-app.git
     cd name-of-the-app
     bin/setup
 


### PR DESCRIPTION
Why:
- We had some references to our old name all over this guides. Also the badge with our old logo wasn't showing.

This change addresses the need by:
- Changing `Group Buddies` to `Subvisual`.
- Changing github urls from `/groupbuddies` to `/subvisual`.
- Removing the badge from `README.md`.
