### PR TITLE
Proposes a rubocop config to be used in all ruby projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Guides for getting things done, programming well, and programming in style.
   * [Sass](/style/sass)
   * [JavaScript](/style/js)
   * [Templating](/style/templating)
+* [Linters](/linters)
 * [Trello](/trello)
 * [Github](/github)
 

--- a/linters/README.md
+++ b/linters/README.md
@@ -1,0 +1,7 @@
+Linters
+=======
+
+Files to configure the linters we use for each language and technology
+
+* Ruby
+  * [Rubocop](/linters/ruby/.rubocop.yml)

--- a/linters/ruby/.rubocop.yml
+++ b/linters/ruby/.rubocop.yml
@@ -1,0 +1,50 @@
+AllCops:
+  Include:
+    - "**/Rakefile"
+    - "**/config.ru"
+  Exclude:
+    - "db/**/*"
+    - "config/**/*"
+    - "script/**/*"
+    - "bin/**/*"
+    - "vendor/**/*"
+    - "node_modules/**/*"
+    - "spec/factories.rb"
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/PredicateName:
+  NamePrefixBlacklist:
+    - is_
+    - have_
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Style/TrailingComma:
+  EnforcedStyleForMultiline: comma


### PR DESCRIPTION
Why:
- We want a way to make sure we are all following the same style guides

This change addresses the need by:
- Having a public place where it is easy to get the configs we all agree
  on, whenever we are starting a project, instead of always be copying and
  pasting from previous projects, which will ultimately lead to
  diferences.
