### PR TITLE
Add eslint config to be used in most JavaScript projects

### DIFF
--- a/linters/README.md
+++ b/linters/README.md
@@ -5,3 +5,5 @@ Files to configure the linters we use for each language and technology
 
 * Ruby
   * [Rubocop](/linters/ruby/.rubocop.yml)
+* JavaScript
+  * [Eslint](/linters/javascript/.eslintrc)

--- a/linters/javascript/.eslintrc
+++ b/linters/javascript/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "extends": "airbnb",
+  "parser": "babel-eslint",
+  "rules": {
+    "consistent-return": 0,
+    "id-length": [2, {"exceptions": ["_", "x", "y"]}],
+    "new-cap": [2, {
+      "capIsNewExceptions": ["CSSModules"]
+    }],
+    "react/no-multi-comp": [2, { "ignoreStateless": true }]
+  }
+}

--- a/linters/javascript/.eslintrc
+++ b/linters/javascript/.eslintrc
@@ -3,7 +3,7 @@
   "parser": "babel-eslint",
   "rules": {
     "consistent-return": 0,
-    "id-length": [2, {"exceptions": ["_", "x", "y"]}],
+    "id-length": [2, {"exceptions": ["_"]}],
     "new-cap": [2, {
       "capIsNewExceptions": ["CSSModules"]
     }],


### PR DESCRIPTION
Why:
- We want our JS style to be uniform across projects.
- This configuration makes two assumptions about the project: (a) it is
  using Babel, (b) it is using react. It may not be the case for every
  project, but because this is the direction we are moving towards it is
  justified to have it on the configuration.
- There is a third assumption: it is a front-end project. This is an assumption because you don't want to transpile code running in node. There are already some es6 features available in node 4, but this configuration will not work. I'll submit a different file to use with node projects.

This change addresses the need by:
- Adding a `.eslintrc` file.
