### PR TITLE
Fixes rubocop.yml on latest rubocop version

### DIFF
--- a/linters/ruby/.rubocop.yml
+++ b/linters/ruby/.rubocop.yml
@@ -46,5 +46,8 @@ Style/SingleLineBlockParams:
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
 
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma


### PR DESCRIPTION
The current rubocop.yml throws an error because one of the cops we had enabled
has been split into two.
