### PR TITLE
Changes relative logo link with fully-qualified URL

### DIFF
--- a/github/templates/README.md
+++ b/github/templates/README.md
@@ -89,6 +89,6 @@ About
 
 ProjectName is maintained by [Subvisual](http://subvisual.co).
 
-[![Subvisual](subvisual_logo_with_name.png)](http://subvisual.co)
+[![Subvisual](https://raw.githubusercontent.com/subvisual/guides/master/github/templates/subvisual_logo_with_name.png)](http://subvisual.co)
 
 If you need to contact the maintainer use [this](https://trello.com/b/svB6ZSce/areas-of-responsability-dris) trello board, or <a href="mailto:contact@subvisual.co">reach out to us</a> if you don't have access.


### PR DESCRIPTION
Why:
- When copying this template to use in other projects, the relative link
  to Subvisual's logo will not work

This change addresses the need by:
- Making the link a fully-qualified URL instead, so that no change is
  needed on that line when using the template
