### PR TITLE
Refactors example for Setup section of README template

### DIFF
--- a/github/templates/README.md
+++ b/github/templates/README.md
@@ -27,21 +27,17 @@ Short project description. You can use the client's pitch. No more than ten line
 Setup
 -----
 
-A set of instructions to install the project. It can start with a list of dependencies, like databases, and finish with the instructions. For instance:
+A set of instructions to install the project. It can start with a list of dependencies, like databases, and finish with the instructions, or it can be a simple list of commands. For instance:
 
-First clone the repository to your file system:
-
-```
-git clone git@github.com:subvisual/guides.git
-```
-
-After, run the setup script:
+First, clone & setup the repository:
 
 ```
+git clone git@github.com:subvisual/PROJECT_NAME.git
+cd PROJECT_NAME
 bin/setup
 ```
 
-To finish, open the file `.env` and replace the values accordingly.
+After that, open the `.env` file in your editor and fill in the required secret values.
 
 Development
 -----------


### PR DESCRIPTION
Why:
- When using this template, I missed the git repo name in the clone
  command because I
  searched for `PROJECT_NAME`
- The `cd` command, albeit being obvious for us, was missing from the
  example. And I believe we can be more direct to the reader and not
  describe every single command individually
