### PR TITLE
Sets rubocop to use Ruby 2.3 parser

### DIFF
--- a/linters/ruby/.rubocop.yml
+++ b/linters/ruby/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - "vendor/**/*"
     - "node_modules/**/*"
     - "spec/factories.rb"
+  TargetRubyVersion: 2.3
 
 Metrics/LineLength:
   Enabled: false

--- a/linters/ruby/.rubocop.yml
+++ b/linters/ruby/.rubocop.yml
@@ -52,3 +52,6 @@ Style/TrailingCommaInArguments:
 
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
+
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
The default is to use the 2.0 parser, which doesn't support some new
syntax such as required keyword arguments and the safe navigation
operator

**UPDATE**: This also disables the frozen string check (which didn't happen in Ruby 2.0, so we weren't getting those warning)
This is for 3 reasons:
1. It's not an easy migration since it involves a lot of work on our part to move to frozen strings as a default
2. It seems to have no statistically significant performance impact. [source](http://ruby-performance-book.com/blog/2016/02/is-ruby-2-3-faster-frozen-string-literals-performance.html?utm_source=rubyweekly&utm_medium=email)
3. Quoting Matz himself: `"All String literals are immutable (frozen) on Ruby 3"`
