### PR TITLE
Fixes indentation for multiline method calls

### DIFF
--- a/linters/ruby/.rubocop.yml
+++ b/linters/ruby/.rubocop.yml
@@ -47,6 +47,9 @@ Style/SingleLineBlockParams:
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 


### PR DESCRIPTION
Why:

This is the new enforced style, and the one we prefer:

``` ruby
@variable = object.
  method_call.
  another_method_call
```
