### PR TITLE
Update copyright year and fix grammar issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ A note on the language:
 Credits
 -------
 
-Thanks to [thoughtbot](http://thoughtbot.com/) from whom this guides are based.
+Thanks to [thoughtbot](http://thoughtbot.com/) from whom these guides are based.
 
-This guides are maintained by [Subvisual](https://subvisual.co)
+These guides are maintained by [Subvisual](https://subvisual.co)
 The names and logos for Subvisual are trademarks of GB-Software As A Service, Lda.
 
-This guides are © 2015 GB-Software As A Service, Lda. They are distributed under the [Creative Commons
+These guides are © 2016 GB-Software As A Service, Lda.
+They are distributed under the [Creative Commons
 Attribution License](http://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
Why:
- The copyright is dated of 2015;
- `This guides` is recurrent in the text.

These changes address the issues by:
- Refactoring the README Credits section.
