### PR TITLE
Rails style rule for route actions order

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -53,6 +53,15 @@ Rails Routes
 * Avoid the `:except` option in routes.
 * Order resourceful routes alphabetically by name.
 * Use the `:only` option to explicitly state exposed routes.
+* When specifying `:only`, order the routes following the resource's lifecycle:
+  `index`, `new`, `create`, `show`, `edit`, `update`, `destroy`.
+  ```ruby
+  # Good
+  resources :posts, only: %i(index new create show destroy)
+
+  # Bad
+  resources :posts, only: %i(index show destroy create new)
+  ```
 
 Background Jobs
 ---------------


### PR DESCRIPTION
Why:
- We have no rule for the order to follow when stating the routes to be
  enabled with the `:only` option, which decreases the consistency of
  the code in the routes file.

This change addresses the need by:
- Proposing the resource lifecycle as the preferred order for stating
  routes.
