### PR TITLE
Adds Elixir linter

### DIFF
--- a/linters/README.md
+++ b/linters/README.md
@@ -8,3 +8,5 @@ Files to configure the linters we use for each language and technology
 
 * CSS
   * [Scss](/linters/css/.scss-lint.yml)
+* Elixir
+  * [Credo](/linters/elixir/.credo.exs)

--- a/linters/elixir/.credo.exs
+++ b/linters/elixir/.credo.exs
@@ -1,0 +1,21 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      files: %{
+        included: ["lib/", "src/", "web/", "apps/"],
+        excluded: [~r"/_build/", ~r"/deps/"]
+      },
+      requires: [],
+      check_for_updates: true,
+      strict: true,
+      color: true,
+
+      checks: [
+        {Credo.Check.Design.TagTODO, exit_status: 0},
+        {Credo.Check.Readability.ModuleDoc, false},
+        {Credo.Check.Readability.Specs, false},
+      ],
+    }
+  ]
+}


### PR DESCRIPTION
Why:

* With the growing number of projects using Elixir, we should try to follow the
same style guides across all of them.

This change addresses the need by:

* Adding a `.credo.exs` file containing a sample configuration.

Notes:

* This PR shouldn't be considered a definitive proposal, but an initial,
open-to-discussion proposal.
* These rules haven't been battle tested, but they are the ones being used in
[atmos](https://github.com/subvisual/atmos).
* The sample configuration was obtained from the [`.credo.exs` file of the credo
repository](https://github.com/rrrene/credo/blob/master/.credo.exs). It contains
all the available linting options.
* I tried to base myself on the Ruby linter, but for the time being, it values
consistency in the current project as opposed to an overall rule for all
projects.
* I, sadly, still haven't found any rule that enforces trailing commas over multiline
maps, function declarations and arrays.