### PR TITLE
Adds a standard SVGO config

### DIFF
--- a/linters/README.md
+++ b/linters/README.md
@@ -5,8 +5,9 @@ Files to configure the linters we use for each language and technology
 
 * Ruby
   * [Rubocop](/linters/ruby/.rubocop.yml)
-
 * CSS
   * [Scss](/linters/css/.scss-lint.yml)
 * Elixir
   * [Credo](/linters/elixir/.credo.exs)
+* SVG Files
+* * [SVGO](/linters/svg/.svgo.yml)

--- a/linters/svg/svgo.yml
+++ b/linters/svg/svgo.yml
@@ -1,0 +1,6 @@
+plugins:
+  # custom options
+  - convertTransform:
+      convertToShorts: false
+  - sortAttrs
+  - removeDimensions


### PR DESCRIPTION
Why:

* I've been using these settings across several projects without any
issues, so I believe they're a good candidate for a general standard

This change addresses the need by:

* Adding a default .svgo.yml as an SVG linter

The configured rules are the ones that by default, and from my experience, have a chance to visually affect the final SVG (i.e.: smaller precision on floating point numbers causes some missalignments), or the way that the browser positions it (i.e.: removing the width and height attribute is not recommended)