### PR TITLE
Only ban AndOr in conditionals

### DIFF
--- a/linters/ruby/.rubocop.yml
+++ b/linters/ruby/.rubocop.yml
@@ -18,7 +18,7 @@ Metrics/LineLength:
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
-Style/AlignParameters:
+Style/AndOr:
   EnforcedStyle: conditionals
 
 Style/ClassAndModuleChildren:

--- a/linters/ruby/.rubocop.yml
+++ b/linters/ruby/.rubocop.yml
@@ -18,6 +18,9 @@ Metrics/LineLength:
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Style/AlignParameters:
+  EnforcedStyle: conditionals
+
 Style/ClassAndModuleChildren:
   Enabled: false
 


### PR DESCRIPTION
Why:

* By default, Rubocop bans the use of `and` and `or` keywords everywhere.
* However, this behaviour is sometimes preferred when not in
conditionals.
* A typical example would be the `redirect_to login_path and return`
pattern.
* The `&&` and `||` do not suffice for this operation but they should
always be the option for boolean checks.

This change addresses the need by:

* Only enforcing `AndOr` restrictions in conditionals.