### PR TITLE
Update Rubocop

### DIFF
--- a/linters/ruby/.rubocop.yml
+++ b/linters/ruby/.rubocop.yml
@@ -10,13 +10,37 @@ AllCops:
     - "vendor/**/*"
     - "node_modules/**/*"
     - "spec/factories.rb"
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
+
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb
+    - lib/tasks/**/*.rake
 
 Metrics/LineLength:
   Enabled: false
 
-Style/AlignParameters:
-  EnforcedStyle: with_fixed_indentation
+Naming/FileName:
+  Exclude:
+    - "Gemfile"
+    - "Brewfile"
+
+Naming/PredicateName:
+  NamePrefixBlacklist:
+    - is_
+    - have_
 
 Style/ClassAndModuleChildren:
   Enabled: false
@@ -24,19 +48,11 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
-Style/DotPosition:
-  EnforcedStyle: trailing
+Style/FrozenStringLiteralComment:
+  Enabled: false
 
 Style/IfUnlessModifier:
   Enabled: false
-
-Style/PredicateName:
-  NamePrefixBlacklist:
-    - is_
-    - have_
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
 
 Style/NumericLiterals:
   Enabled: false
@@ -44,17 +60,14 @@ Style/NumericLiterals:
 Style/SingleLineBlockParams:
   Enabled: false
 
-Style/MultilineOperationIndentation:
-  EnforcedStyle: indented
-
-Style/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma


### PR DESCRIPTION
Why:

* Some rules changed in the new versions of Rubocop.
* New Ruby versions have since been made available.

This change addresses the need by:

* Updating the rubocop rules to match the same behaviour but under the
new naming.