### PR TITLE
Add .formatter.exs

### DIFF
--- a/linters/elixir/.formatter.exs
+++ b/linters/elixir/.formatter.exs
@@ -1,0 +1,44 @@
+[
+  inputs: [
+    "mix.exs",
+    "{config,lib,test,priv}/**/*.{ex,exs}",
+    "apps/*/mix.exs",
+    "apps/*/{config,lib,test,priv}/**/*.{ex,exs}"
+  ],
+  line_length: 80,
+  locals_without_parens: [
+    # elixir
+    defstruct: :*,
+    defmodule: :*,
+    send: :*,
+    spawn: :*,
+
+    # ecto
+    create: :*,
+    drop: :*,
+    remove: :*,
+    field: :*,
+    schema: :*,
+    add: :*,
+
+    # vex
+    validates: :*,
+
+    # plug
+    plug: :*,
+
+    # phoenix
+    pipe_through: :*,
+    forward: :*,
+    get: :*,
+    post: :*,
+    patch: :*,
+    put: :*,
+    delete: :*,
+    resources: :*,
+    pipeline: :*,
+    scope: :*,
+    socket: :*,
+    adapter: :*
+  ]
+]

--- a/linters/elixir/.formatter.exs
+++ b/linters/elixir/.formatter.exs
@@ -20,6 +20,7 @@
     field: :*,
     schema: :*,
     add: :*,
+    rename: :*,
 
     # vex
     validates: :*,


### PR DESCRIPTION
Why:

* With the addition of mix format in Elixir 1.6, we have defaulted to
using the formatter.

This change addresses the need by:

* Adding a sample `.formatter.exs` file that takes into account the
defaults use by Elixir.
* Setting some functions that are supposed to have their parenthesis
ignored (mainly related to Elixir DSLs).