### PR TITLE
Update GitHub README template

### DIFF
--- a/github/templates/README.md
+++ b/github/templates/README.md
@@ -112,11 +112,26 @@ This section should list every online resource that is relevant to the project. 
 * Link to Invision files.
 * ...
 
+License
+-------
+
+_Only relevant for public repositories._
+
+PROJECT_NAME is copyright &copy; 2020 Subvisual, Lda.
+
+It is open-source, made available for free, and is subject to the terms in
+its [license].
+
+
 About
 -----
 
-PROJECT_NAME is maintained by [Subvisual](http://subvisual.com).
+PROJECT_NAME was created and is maintained with :heart: by
+[Subvisual][subvisual].
 
-[![Subvisual](https://raw.githubusercontent.com/subvisual/guides/master/github/templates/logos/blue@4x.png)](http://subvisual.com)
+[![Subvisual][subvisual-logo]][subvisual]
 
-If you need to contact the maintainer, you may <a href="mailto:contact@subvisual.com">reach out to us</a> or use [this](https://trello.com/b/svB6ZSce/areas-of-responsability-dris) Trello board.
+
+[license]: ./LICENSE.txt
+[subvisual]: http://subvisual.com
+[subvisual-logo]: https://raw.githubusercontent.com/subvisual/guides/master/github/templates/logos/blue.png


### PR DESCRIPTION
Why:

* The template does not include a license section, relevant for open-source projects.
* About section is too formal for an open-source project, includes the contact e-mail
  when we would prefer to be contacted through GitHub, and assumes Trello for
  project management, which we have ditched long ago.
* Current logo is also too big for most cases.